### PR TITLE
Fix typo in pillager_outposts.json exclusion_zone

### DIFF
--- a/src/main/resources/data/minecraft/worldgen/structure_set/pillager_outposts.json
+++ b/src/main/resources/data/minecraft/worldgen/structure_set/pillager_outposts.json
@@ -55,7 +55,7 @@
 		"frequency_reduction_method": "legacy_type_1",
 		"frequency": 0.2,
 		"exclusion_zone": {
-			"other_set": "minecraft:village",
+			"other_set": "minecraft:villages",
 			"chunk_count": 10
 		},
 		"spacing": 32,


### PR DESCRIPTION
Fix typo in pillager outposts exclusion zone. Pillager outputs will now properly be 10 chunks away from villages like in vanilla minecraft.