### PR TITLE
Remove meaningless 'name' field from template pools

### DIFF
--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/badlands/base_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/badlands/base_plates.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:pillager_outpost/badlands/base_plates",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/badlands/feature_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/badlands/feature_plates.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/badlands/feature_plates",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/badlands/features.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/badlands/features.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/badlands/features",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/badlands/tower.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/badlands/tower.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/badlands/tower",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/beach/base_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/beach/base_plates.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:pillager_outpost/beach/base_plates",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/beach/feature_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/beach/feature_plates.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/beach/feature_plates",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/beach/features.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/beach/features.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/beach/features",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/beach/tower.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/beach/tower.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/beach/tower",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/dark_forest/base_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/dark_forest/base_plates.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:pillager_outpost/dark_forest/base_plates",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/dark_forest/feature_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/dark_forest/feature_plates.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/dark_forest/feature_plates",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/dark_forest/features.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/dark_forest/features.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/dark_forest/features",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/dark_forest/tower.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/dark_forest/tower.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/dark_forest/tower",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/desert/base_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/desert/base_plates.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:pillager_outpost/desert/base_plates",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/desert/feature_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/desert/feature_plates.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/desert/feature_plates",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/desert/features.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/desert/features.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/desert/features",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/desert/tower.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/desert/tower.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/desert/tower",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/jungle/base_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/jungle/base_plates.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:pillager_outpost/jungle/base_plates",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/jungle/feature_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/jungle/feature_plates.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/jungle/feature_plates",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/jungle/features.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/jungle/features.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/jungle/features",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/jungle/tower.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/jungle/tower.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/jungle/tower",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/mountain/base_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/mountain/base_plates.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:pillager_outpost/mountain/base_plates",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/mountain/feature_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/mountain/feature_plates.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/mountain/feature_plates",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/mountain/features.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/mountain/features.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/mountain/features",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/mountain/tower.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/mountain/tower.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/mountain/tower",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/plains/base_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/plains/base_plates.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:pillager_outpost/plains/base_plates",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/plains/feature_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/plains/feature_plates.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/plains/feature_plates",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/plains/features.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/plains/features.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/plains/features",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/plains/tower.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/plains/tower.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/plains/tower",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/savanna/base_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/savanna/base_plates.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:pillager_outpost/savanna/base_plates",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/savanna/feature_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/savanna/feature_plates.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/savanna/feature_plates",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/savanna/features.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/savanna/features.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/savanna/features",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/savanna/tower.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/savanna/tower.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/savanna/tower",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/snowy/base_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/snowy/base_plates.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:pillager_outpost/snowy/base_plates",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/snowy/feature_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/snowy/feature_plates.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/snowy/feature_plates",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/snowy/features.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/snowy/features.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/snowy/features",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/snowy/tower.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/snowy/tower.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/snowy/tower",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/swamp/base_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/swamp/base_plates.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:pillager_outpost/swamp/base_plates",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/swamp/feature_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/swamp/feature_plates.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/swamp/feature_plates",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/swamp/features.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/swamp/features.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/swamp/features",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/swamp/tower.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/swamp/tower.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/swamp/tower",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/taiga/base_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/taiga/base_plates.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:pillager_outpost/taiga/base_plates",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/taiga/feature_plates.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/taiga/feature_plates.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/taiga/feature_plates",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/taiga/features.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/taiga/features.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/taiga/features",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/taiga/tower.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/pillager_outpost/taiga/tower.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:pillager_outpost/taiga/tower",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/beach/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/beach/deco.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/beach/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/beach/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/beach/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/beach/house",
 	"fallback": "ctov:village/beach/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/beach/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/beach/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/beach/road",
 	"fallback": "ctov:village/beach/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/beach/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/beach/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/beach/terminator",
     "fallback": "minecraft:empty",
     "elements": [
       {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/christmas/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/christmas/deco.json
@@ -1,5 +1,4 @@
 {
-	"name":"ctov:village/christmas/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/christmas/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/christmas/house.json
@@ -1,5 +1,4 @@
 {
-	"name":"ctov:village/christmas/house",
 	"fallback": "ctov:village/christmas/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/christmas/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/christmas/roads.json
@@ -1,5 +1,4 @@
 {
-	"name":"ctov:village/christmas/road",
 	"fallback": "ctov:village/christmas/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/christmas/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/christmas/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/christmas/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/christmas/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/christmas/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/snowy",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/animals.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/animals.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/common/animals",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/bees.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/bees.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/common/bees",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/bounty_board.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/bounty_board.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/common/bounty_board",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/cow.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/cow.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/common/cow",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/flowers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/flowers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/common/sheep",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/sheep.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/sheep.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/common/sheep",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/desert.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/desert.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/common/villager/desert",
     "fallback":"minecraft:empty",
     "elements":[
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/jungle.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/jungle.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/common/villager/jungle",
     "fallback":"minecraft:empty",
     "elements":[
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/plain.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/plain.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/common/villager/plain",
     "fallback":"minecraft:empty",
     "elements":[
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/savanna.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/savanna.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/common/villager/savanna",
     "fallback":"minecraft:empty",
     "elements":[
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/snow.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/snow.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/common/villager/snow",
     "fallback":"minecraft:empty",
     "elements":[
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/swamp.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/swamp.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/common/villager/swamp",
     "fallback":"minecraft:empty",
     "elements":[
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/taiga.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/villager/taiga.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/common/villager/taiga",
     "fallback":"minecraft:empty",
     "elements":[
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/waystone/mossy.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/waystone/mossy.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/common/waystone/mossy",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/waystone/normal.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/waystone/normal.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/common/waystone/normal",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/waystone/sand.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/common/waystone/sand.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/common/waystone/sand",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert/deco.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/desert/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/desert/house",
 	"fallback": "ctov:village/desert/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert/roads.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/desert/road",
     "fallback": "ctov:village/desert/terminator",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/desert/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/biome/desert",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert_oasis/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert_oasis/deco.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/desert_oasis/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert_oasis/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert_oasis/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/desert_oasis/house",
 	"fallback": "ctov:village/desert_oasis/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert_oasis/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert_oasis/roads.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/desert_oasis/road",
     "fallback": "ctov:village/desert_oasis/terminator",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert_oasis/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert_oasis/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/desert_oasis/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert_oasis/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/desert_oasis/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/biome/desert",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/halloween/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/halloween/deco.json
@@ -1,5 +1,4 @@
 {
-		"name": "ctov:village/halloween/deco",
 		"fallback": "minecraft:empty",
 		"elements": [
 			{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/halloween/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/halloween/house.json
@@ -1,5 +1,4 @@
 {
-		"name": "ctov:village/halloween/house",
 		"fallback": "ctov:village/halloween/deco",
 		"elements": [
 			{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/halloween/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/halloween/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/halloween/road",
 	"fallback": "ctov:village/halloween/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/halloween/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/halloween/terminator.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/halloween/terminator",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/halloween/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/halloween/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/dark_forest",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle/deco.json
@@ -1,5 +1,4 @@
 {
-	"name":"ctov:village/jungle/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle/house.json
@@ -1,5 +1,4 @@
 {
-	"name":"ctov:village/jungle/house",
 	"fallback": "ctov:village/jungle/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle/roads.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/jungle/road",
     "fallback": "ctov:village/jungle/terminator",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/jungle/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/jungle",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle_tree/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle_tree/house.json
@@ -1,5 +1,4 @@
 {
-	"name":"ctov:village/jungle_tree/house",
 	"fallback":"ctov:village/jungle_tree/house_terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle_tree/house_terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle_tree/house_terminator.json
@@ -1,5 +1,4 @@
 {
-	"name":"ctov:village/jungle_tree/house_terminator",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle_tree/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle_tree/roads.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/jungle_tree/road",
     "fallback": "ctov:village/jungle_tree/terminator",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle_tree/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle_tree/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/jungle_tree/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle_tree/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/jungle_tree/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/jungle",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa/deco.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/mesa/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/mesa/house",
 	"fallback": "ctov:village/mesa/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/mesa/road",
 	"fallback": "ctov:village/mesa/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/mesa/terminator",
     "fallback": "minecraft:empty",
     "elements": [
       {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/mesa",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa_fortified/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa_fortified/deco.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/mesa_fortified/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa_fortified/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa_fortified/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/mesa_fortified/house",
 	"fallback": "ctov:village/mesa_fortified/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa_fortified/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa_fortified/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/mesa_fortified/road",
 	"fallback": "ctov:village/mesa_fortified/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa_fortified/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa_fortified/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/mesa_fortified/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa_fortified/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa_fortified/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/mesa",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa_fortified/tree.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mesa_fortified/tree.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/mesa_fortified/tree",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain/deco.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/mountain/deco",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/mountain/house",
 	"fallback": "ctov:village/mountain/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/mountain/road",
 	"fallback": "ctov:village/mountain/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/mountain/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/mountain",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain_alpine/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain_alpine/deco.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/mountain_alpine/deco",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain_alpine/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain_alpine/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/mountain_alpine/house",
 	"fallback": "ctov:village/mountain_alpine/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain_alpine/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain_alpine/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/mountain_alpine/road",
 	"fallback": "ctov:village/mountain_alpine/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain_alpine/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain_alpine/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/mountain_alpine/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain_alpine/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mountain_alpine/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/mountain",
     "fallback": "minecraft:empty",
     "elements": [
             {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mushroom/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mushroom/deco.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/mushroom/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mushroom/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mushroom/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/mushroom/house",
 	"fallback": "ctov:village/mushroom/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mushroom/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mushroom/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/mushroom/road",
 	"fallback": "ctov:village/mushroom/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mushroom/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mushroom/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/mushroom/terminator",
     "fallback": "minecraft:empty",
     "elements": [
       {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/mushroom/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/mushroom/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/biome/mushroom",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains/deco.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/plains/decos",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/plains/house",
 	"fallback": "ctov:village/plains/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/plains/road",
 	"fallback": "ctov:village/plains/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/plains/terminator",
     "fallback": "minecraft:empty",
     "elements": [
       {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/plains",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains_fortified/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains_fortified/deco.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/plains_fortified/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains_fortified/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains_fortified/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/plains_fortified/house",
 	"fallback": "ctov:village/plains_fortified/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains_fortified/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains_fortified/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/plains_fortified/road",
 	"fallback": "ctov:village/plains_fortified/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains_fortified/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains_fortified/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/plains_fortified/terminator",
     "fallback": "minecraft:empty",
     "elements": [
       {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains_fortified/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/plains_fortified/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/plains",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna/deco.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/savanna/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna/roads.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/savanna/road",
     "fallback": "ctov:village/savanna/terminator",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/savanna/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna/town_centers.json
@@ -1,5 +1,4 @@
 {
-	"name":"ctov:village/biome/savanna",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna_na/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna_na/deco.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/savanna_na/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna_na/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna_na/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/savanna_na/house",
 	"fallback": "ctov:village/savanna_na/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna_na/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna_na/roads.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/savanna_na/road",
     "fallback": "ctov:village/savanna_na/terminator",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna_na/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna_na/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/savanna_na/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna_na/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/savanna_na/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/savanna",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/snowy_igloo/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/snowy_igloo/deco.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/snowy_igloo/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/snowy_igloo/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/snowy_igloo/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/snowy_igloo/house",
 	"fallback": "ctov:village/snowy_igloo/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/snowy_igloo/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/snowy_igloo/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/snowy/road",
 	"fallback": "ctov:village/snowy_igloo/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/snowy_igloo/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/snowy_igloo/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/snowy_igloo/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/snowy_igloo/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/snowy_igloo/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/snowy",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp/deco.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/swamp/deco",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/swamp/house",
 	"fallback": "ctov:village/swamp/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/swamp/road",
 	"fallback": "ctov:village/swamp/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/swamp/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/swamp",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp_fortified/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp_fortified/deco.json
@@ -1,5 +1,4 @@
 {
-    "name": "ctov:village/swamp_fortified/deco",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp_fortified/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp_fortified/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/swamp_fortified/house",
 	"fallback": "ctov:village/swamp_fortified/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp_fortified/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp_fortified/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/swamp_fortified/road",
 	"fallback": "ctov:village/swamp_fortified/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp_fortified/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/swamp_fortified/terminator.json
@@ -1,5 +1,4 @@
 {
-	"name":"ctov:village/swamp_fortified/terminator",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga/deco.json
@@ -1,5 +1,4 @@
 {
-	"name":"ctov:village/taiga/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/taiga/house",
 	"fallback": "ctov:village/taiga/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/taiga/road",
 	"fallback": "ctov:village/taiga/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/taiga/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga/town_centers.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga/town_centers.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/biome/taiga",
     "fallback": "minecraft:empty",
     "elements": 
     [

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga_fortified/deco.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga_fortified/deco.json
@@ -1,5 +1,4 @@
 {
-	"name":"ctov:village/taiga_fortified/deco",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga_fortified/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga_fortified/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/taiga_fortified/house",
 	"fallback": "ctov:village/taiga_fortified/deco",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga_fortified/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga_fortified/roads.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/taiga_fortified/road",
 	"fallback": "ctov:village/taiga_fortified/terminator",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga_fortified/terminator.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/taiga_fortified/terminator.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/taiga_fortified/terminator",
     "fallback": "minecraft:empty",
     "elements": [
         {

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/underground/house.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/underground/house.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/underground/house",
 	"fallback": "ctov:village/underground/wall",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/underground/roads.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/underground/roads.json
@@ -1,5 +1,4 @@
 {
-    "name":"ctov:village/underground/road",
     "fallback": "ctov:village/underground/small_wall",
     "elements": 
     [

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/underground/small_wall.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/underground/small_wall.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/underground/small_wall",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/underground/start.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/underground/start.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/underground/start",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/underground/town_center.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/underground/town_center.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/underground/town_center",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/common/src/main/resources/data/ctov/worldgen/template_pool/village/underground/wall.json
+++ b/common/src/main/resources/data/ctov/worldgen/template_pool/village/underground/wall.json
@@ -1,5 +1,4 @@
 {
-	"name": "ctov:village/underground/wall",
 	"fallback": "minecraft:empty",
 	"elements": [
 		{

--- a/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/badlands.json
+++ b/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/badlands.json
@@ -1,5 +1,4 @@
 {
-    "name": "monobank:village/monobank/badlands",
     "fallback": "monobank:village/monobank/badlands",
     "elements": [
       {

--- a/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/beach.json
+++ b/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/beach.json
@@ -1,5 +1,4 @@
 {
-  "name": "monobank:village/monobank/beach",
   "fallback": "monobank:village/monobank/beach",
   "elements": [
     {

--- a/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/dark_forest.json
+++ b/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/dark_forest.json
@@ -1,5 +1,4 @@
 {
-    "name": "monobank:village/monobank/dark_forest",
     "fallback": "monobank:village/monobank/dark_forest",
     "elements": [
       {

--- a/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/jungle.json
+++ b/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/jungle.json
@@ -1,5 +1,4 @@
 {
-    "name": "monobank:village/monobank/jungle",
     "fallback": "monobank:village/monobank/jungle",
     "elements": [
       {

--- a/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/mountain.json
+++ b/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/mountain.json
@@ -1,5 +1,4 @@
 {
-    "name": "monobank:village/monobank/mountain",
     "fallback": "monobank:village/monobank/mountain",
     "elements": [
       {

--- a/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/mushroom.json
+++ b/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/mushroom.json
@@ -1,5 +1,4 @@
 {
-    "name": "monobank:village/monobank/mushroom",
     "fallback": "monobank:village/monobank/mushroom",
     "elements": [
       {

--- a/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/swamp.json
+++ b/forge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/swamp.json
@@ -1,5 +1,4 @@
 {
-	"name": "monobank:village/monobank/swamp",
 	"fallback": "monobank:village/monobank/swamp",
 	"elements": [
 	  {

--- a/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/badlands.json
+++ b/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/badlands.json
@@ -1,5 +1,4 @@
 {
-    "name": "monobank:village/monobank/badlands",
     "fallback": "monobank:village/monobank/badlands",
     "elements": [
       {

--- a/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/beach.json
+++ b/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/beach.json
@@ -1,5 +1,4 @@
 {
-  "name": "monobank:village/monobank/beach",
   "fallback": "monobank:village/monobank/beach",
   "elements": [
     {

--- a/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/dark_forest.json
+++ b/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/dark_forest.json
@@ -1,5 +1,4 @@
 {
-    "name": "monobank:village/monobank/dark_forest",
     "fallback": "monobank:village/monobank/dark_forest",
     "elements": [
       {

--- a/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/jungle.json
+++ b/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/jungle.json
@@ -1,5 +1,4 @@
 {
-    "name": "monobank:village/monobank/jungle",
     "fallback": "monobank:village/monobank/jungle",
     "elements": [
       {

--- a/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/mountain.json
+++ b/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/mountain.json
@@ -1,5 +1,4 @@
 {
-    "name": "monobank:village/monobank/mountain",
     "fallback": "monobank:village/monobank/mountain",
     "elements": [
       {

--- a/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/mushroom.json
+++ b/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/mushroom.json
@@ -1,5 +1,4 @@
 {
-    "name": "monobank:village/monobank/mushroom",
     "fallback": "monobank:village/monobank/mushroom",
     "elements": [
       {

--- a/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/swamp.json
+++ b/neoforge/src/main/resources/data/monobank/worldgen/template_pool/village/monobank/swamp.json
@@ -1,5 +1,4 @@
 {
-	"name": "monobank:village/monobank/swamp",
 	"fallback": "monobank:village/monobank/swamp",
 	"elements": [
 	  {


### PR DESCRIPTION
This property has, as far as I can tell, never affected anything. The ID from the file path is always used instead. The field and the path sometimes disagreed, which was extra confusing.