### PR TITLE
Fix references to dark_forest instead of halloween in compat

### DIFF
--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/archers/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/archers/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/halloween/house",
-					"location": "ctov:village/dark_forest/jobsite/archery_range"
+					"location": "ctov:village/halloween/jobsite/archery_range"
 				},
 				"limit": 1 
 			}

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/cloudstorage/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/cloudstorage/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/halloween/house",
-					"location": "ctov:village/dark_forest/jobsite/balloon_stand"
+					"location": "ctov:village/halloween/jobsite/balloon_stand"
 				},
 				"count": 1,
                 "min_depth": 3

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/easel/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/easel/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/halloween/house",
-					"location": "ctov:village/dark_forest/jobsite/artist_studio"
+					"location": "ctov:village/halloween/jobsite/artist_studio"
 				},
 				"limit": 1 
 			}

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/irons_jewelry/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/irons_jewelry/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/halloween/house",
-					"location": "ctov:village/dark_forest/jobsite/irons_jewelry"
+					"location": "ctov:village/halloween/jobsite/irons_jewelry"
 				},
 				"limit": 1 
 			}

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/irons_spellbooks/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/irons_spellbooks/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/halloween/house",
-					"location": "ctov:village/dark_forest/jobsite/priest_tower"
+					"location": "ctov:village/halloween/jobsite/priest_tower"
 				},
 				"limit": 1 
 			}

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/jewelry/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/jewelry/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/halloween/house",
-					"location": "ctov:village/dark_forest/jobsite/jewelry_shop"
+					"location": "ctov:village/halloween/jobsite/jewelry_shop"
 				},
 				"limit": 1 
 			}

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/jmc/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/jmc/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/halloween/house",
-					"location": "ctov:village/dark_forest/jobsite/bakery"
+					"location": "ctov:village/halloween/jobsite/bakery"
 				},
 				"limit": 1 
 			}

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/paladins/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/paladins/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/halloween/house",
-					"location": "ctov:village/dark_forest/jobsite/sanctuary"
+					"location": "ctov:village/halloween/jobsite/sanctuary"
 				},
 				"limit": 1 
 			}

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/respawn_obelisk/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/respawn_obelisk/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/plains/roads",
-					"location": "ctov:village/dark_forest/roads/respawn_obelisk"
+					"location": "ctov:village/halloween/roads/respawn_obelisk"
 				},
 				"limit": 1 
 			}

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/rogues/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/rogues/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/halloween/house",
-					"location": "ctov:village/dark_forest/jobsite/barracks"
+					"location": "ctov:village/halloween/jobsite/barracks"
 				},
 				"limit": 1 
 			}

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/scorchedguns/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/scorchedguns/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/halloween/house",
-					"location": "ctov:village/dark_forest/jobsite/gunsmith"
+					"location": "ctov:village/halloween/jobsite/gunsmith"
 				},
 				"limit": 1 
 			}

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/village_taverns/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/village_taverns/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/halloween/house",
-					"location": "ctov:village/dark_forest/jobsite/tavern"
+					"location": "ctov:village/halloween/jobsite/tavern"
 				},
 				"limit": 1 
 			}

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/vinery/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/vinery/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/halloween/house",
-					"location": "ctov:village/dark_forest/jobsite/vineyard"
+					"location": "ctov:village/halloween/jobsite/vineyard"
 				},
 				"limit": 1
 			}

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/wizards/dark_forest.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/wizards/dark_forest.json
@@ -22,7 +22,7 @@
 					"element_type": "minecraft:single_pool_element",
 					"projection": "rigid",
 					"processors": "ctov:village/halloween/house",
-					"location": "ctov:village/dark_forest/jobsite/wizard_tower"
+					"location": "ctov:village/halloween/jobsite/wizard_tower"
 				},
 				"limit": 1 
 			}


### PR DESCRIPTION
Much like with `mesa` vs `badlands`, the dark forest village is inconsistently named `dark_forest` or `halloween` in different places. I fixed the broken references here. Alternatively, do you think it'd make more sense to make the names consistent by renaming `halloween` to `dark_forest` everywhere so that this class of errors disappears entirely?