### PR TITLE
Jungle village: Move modded structures from 'terminator' pool to 'house' pool

### DIFF
--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/advancedperipherals/jungle.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/advancedperipherals/jungle.json
@@ -12,7 +12,7 @@
 			"modid": "advancedperipherals"
 		}
 	],
-	"template_pools": "ctov:village/jungle/terminator",
+	"template_pools": "ctov:village/jungle/house",
 	"elements": [
 		{
 			"weight": 5,

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/cobblemon/jungle.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/cobblemon/jungle.json
@@ -12,7 +12,7 @@
 			"modid": "cobblemon"
 		}
 	],
-	"template_pools": "ctov:village/jungle/terminator",
+	"template_pools": "ctov:village/jungle/house",
 	"elements": [
 		{
 			"weight": 5,

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/iceandfire/jungle.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/iceandfire/jungle.json
@@ -12,7 +12,7 @@
 			"modid": "iceandfire"
 		}
 	],
-	"template_pools": "ctov:village/jungle/terminator",
+	"template_pools": "ctov:village/jungle/house",
 	"elements": [
 		{
 			"weight": 5,

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/immersiveengineering/jungle.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/immersiveengineering/jungle.json
@@ -12,7 +12,7 @@
 			"modid": "immersiveengineering"
 		}
 	],
-	"template_pools": "ctov:village/jungle/terminator",
+	"template_pools": "ctov:village/jungle/house",
 	"elements": [
 		{
 			"weight": 5,

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/monobank/jungle.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/monobank/jungle.json
@@ -12,7 +12,7 @@
 			"modid": "monobank"
 		}
 	],
-	"template_pools": "ctov:village/jungle/terminator",
+	"template_pools": "ctov:village/jungle/house",
 	"elements": [
 		{
 			"weight": 5,

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/morevillagers/jungle.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/morevillagers/jungle.json
@@ -12,7 +12,7 @@
 			"modid": "morevillagers"
 		}
 	],
-	"template_pools": "ctov:village/jungle/terminator",
+	"template_pools": "ctov:village/jungle/house",
 	"elements": [
 		{
 			"weight": 5,

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/pneumaticcraft/jungle.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/pneumaticcraft/jungle.json
@@ -12,7 +12,7 @@
 			"modid": "pneumaticcraft"
 		}
 	],
-	"template_pools": "ctov:village/jungle/terminator",
+	"template_pools": "ctov:village/jungle/house",
 	"elements": [
 		{
 			"weight": 5,

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/villagersplus/jungle.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/villagersplus/jungle.json
@@ -12,7 +12,7 @@
 			"modid": "villagersplus"
 		}
 	],
-	"template_pools": "ctov:village/jungle/terminator",
+	"template_pools": "ctov:village/jungle/house",
 	"elements": [
 		{
 			"weight": 5,

--- a/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/wares/jungle.json
+++ b/common/src/main/resources/data/ctov/lithostitched/worldgen_modifier/wares/jungle.json
@@ -12,7 +12,7 @@
 			"modid": "wares"
 		}
 	],
-	"template_pools": "ctov:village/jungle/terminator",
+	"template_pools": "ctov:village/jungle/house",
 	"elements": [
 		{
 			"weight": 5,


### PR DESCRIPTION
I have no clue why they're in a different pool from every other village, this change seems straightforwardly correct, and it ensures that the houses actually generate. The jungle_tree village suffers from a similar issue, but that one's much more difficult to solve, so it's going to be in a different PR.